### PR TITLE
Restricting the drawGobPath to humans, it's better that way. I guess one...

### DIFF
--- a/src/haven/MapView.java
+++ b/src/haven/MapView.java
@@ -1493,11 +1493,13 @@ public class MapView extends Widget implements DTarget, Console.Directory {
 	g.chcolor(Color.ORANGE);
 	synchronized (glob.oc) {
 	    for (Gob gob : glob.oc){
-		if(gob.sc == null){continue;}
-		m = gob.getattr(Moving.class);
-		if((m!=null)&&(m instanceof LinMove)){
-		    lm = (LinMove) m;
-		    g.line(gob.sc, m2s(lm.t).add(oc), 2);
+		if (gob.isHuman()) {    	
+			if(gob.sc == null){continue;}
+			m = gob.getattr(Moving.class);
+			if((m!=null)&&(m instanceof LinMove)){
+			    lm = (LinMove) m;
+			    g.line(gob.sc, m2s(lm.t).add(oc), 2);
+			}
 		}
 	    }
 	}


### PR DESCRIPTION
... could add it for dragonflies as well as an option, but I don't see it being that useful for any other gob types.
